### PR TITLE
Verify ZFS source tarballs with recorded hashes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,7 +26,6 @@ RUN [[ "$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2)" == "${FEDORA_VER
 #
 #####
 FROM quay.io/fedora/fedora:${FEDORA_VERSION} as builder
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ZFS_VERSION
 ARG FEDORA_VERSION
 COPY --from=kernel-query /kernel-version.txt /kernel-version.txt

--- a/Containerfile
+++ b/Containerfile
@@ -26,9 +26,11 @@ RUN [[ "$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2)" == "${FEDORA_VER
 #
 #####
 FROM quay.io/fedora/fedora:${FEDORA_VERSION} as builder
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG ZFS_VERSION
 ARG FEDORA_VERSION
 COPY --from=kernel-query /kernel-version.txt /kernel-version.txt
+COPY scripts/zfs-source-hashes.sh /tmp/zfs-source-hashes.sh
 
 # Need to add the updates archive to install specific kernel versions
 RUN dnf install -y fedora-repos-archive
@@ -46,9 +48,21 @@ RUN KERNEL_VERSION="$(cat /kernel-version.txt)" && \
 
 # Build ZFS
 WORKDIR /zfs
-RUN export KERNEL_VERSION="$(cat /kernel-version.txt)" && \
-    curl -L "https://github.com/openzfs/zfs/archive/refs/tags/${ZFS_VERSION}.tar.gz" | \
-        tar xzf - -C . --strip-components 1
+RUN set -euo pipefail \
+    && source /tmp/zfs-source-hashes.sh \
+    && EXPECTED_HASH="$(lookup_zfs_tarball_hash "$ZFS_VERSION")" \
+    && TARBALL_PATH="$(mktemp)" \
+    && curl --fail --location "https://github.com/openzfs/zfs/archive/refs/tags/${ZFS_VERSION}.tar.gz" \
+        --output "$TARBALL_PATH" \
+    && ACTUAL_HASH="$(sha256sum "$TARBALL_PATH" | awk '{print $1}')" \
+    && if [[ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]]; then \
+        echo "ERROR: Hash mismatch for ${ZFS_VERSION}" >&2; \
+        echo "Expected: $EXPECTED_HASH" >&2; \
+        echo "Actual:   $ACTUAL_HASH" >&2; \
+        exit 1; \
+    fi \
+    && tar xzf "$TARBALL_PATH" -C . --strip-components 1 \
+    && rm -f "$TARBALL_PATH"
 
 RUN export KERNEL_VERSION="$(cat /kernel-version.txt)" && \
     ./autogen.sh && \

--- a/Justfile
+++ b/Justfile
@@ -7,6 +7,16 @@ _default:
 zfs-version:
     ./scripts/query-zfs-version.sh | jq -r '.["zfs-tag"]'
 
+# Compute the sha256 for a ZFS release tarball
+zfs-tarball-hash TAG:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    TARBALL_PATH=$(mktemp)
+    trap 'rm -f "$TARBALL_PATH"' EXIT
+    curl --fail --location "https://github.com/openzfs/zfs/archive/refs/tags/{{TAG}}.tar.gz" \
+        --output "$TARBALL_PATH"
+    sha256sum "$TARBALL_PATH" | awk '{print $1}'
+
 # Get kernel version from Fedora CoreOS stable (super fast with remote inspection)
 kernel-version:
     ./scripts/query-kernel-info.sh | jq -r '.["kernel-version"]'

--- a/scripts/zfs-source-hashes.sh
+++ b/scripts/zfs-source-hashes.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2034 # Allow unused associative array when sourced
+declare -A ZFS_TARBALL_SHA256S=(
+  ["zfs-2.2.7"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.2.7__"
+  ["zfs-2.2.8"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.2.8__"
+  ["zfs-2.3.0"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.3.0__"
+  ["zfs-2.3.1"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.3.1__"
+  ["zfs-2.3.2"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.3.2__"
+  ["zfs-2.3.3"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.3.3__"
+  ["zfs-2.3.4"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.3.4__"
+)
+
+lookup_zfs_tarball_hash() {
+  local zfs_version="$1"
+  local hash="${ZFS_TARBALL_SHA256S[$zfs_version]:-}"
+
+  if [[ -z "$hash" ]]; then
+    echo "ERROR: Unknown ZFS version $zfs_version" >&2
+    echo "Please update scripts/zfs-source-hashes.sh with the expected hash." >&2
+    return 1
+  fi
+
+  if [[ "$hash" == __REPLACE_WITH_ACTUAL_SHA256_FOR_*__ ]]; then
+    echo "ERROR: Placeholder hash detected for $zfs_version." >&2
+    echo "Please replace the placeholder in scripts/zfs-source-hashes.sh with the real sha256." >&2
+    return 1
+  fi
+
+  printf '%s\n' "$hash"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <zfs_version>" >&2
+    exit 1
+  fi
+
+  if ! lookup_zfs_tarball_hash "$1"; then
+    exit 1
+  fi
+fi

--- a/scripts/zfs-source-hashes.sh
+++ b/scripts/zfs-source-hashes.sh
@@ -2,13 +2,13 @@
 
 # shellcheck disable=SC2034 # Allow unused associative array when sourced
 declare -A ZFS_TARBALL_SHA256S=(
-  ["zfs-2.2.7"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.2.7__"
-  ["zfs-2.2.8"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.2.8__"
-  ["zfs-2.3.0"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.3.0__"
-  ["zfs-2.3.1"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.3.1__"
-  ["zfs-2.3.2"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.3.2__"
-  ["zfs-2.3.3"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.3.3__"
-  ["zfs-2.3.4"]="__REPLACE_WITH_ACTUAL_SHA256_FOR_zfs-2.3.4__"
+  ["zfs-2.2.7"]="c144057d631d8a1a140f78db884b207e811c42a35ee4c3a6504ad438f237d974"
+  ["zfs-2.2.8"]="a57b2cdd6ad5c15373d2e64313c2858e13530d0f255183db17b6a740e1a745c0"
+  ["zfs-2.3.0"]="d4e8343c2ad91301c08d47df9b32d5ec4c9fe458d00e74df41e0d58ecbd44bfd"
+  ["zfs-2.3.1"]="b870b9e21a34e6f14e04bcaf3795d14ce57270ea1f339f12b4cad25a10841e74"
+  ["zfs-2.3.2"]="877a6b37755245955fadd68cee2f2729f7acc10e2aad5dd77a6426a8d46aca83"
+  ["zfs-2.3.3"]="ba8db7766e6724dc1c1b9287174bc9022dab521919d3353dc488aad9e55de541"
+  ["zfs-2.3.4"]="940af1303a01df3228b3e136a2ae99bb4d7a894f71f804cf7d3ae198f959dd46"
 )
 
 lookup_zfs_tarball_hash() {


### PR DESCRIPTION
## Summary
- copy a static map of expected ZFS source tarball hashes into the build context
- verify downloaded ZFS sources against the recorded hash during the build
- add a Just command to compute a tarball hash for populating the placeholders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f43ca583a08329bb67d6a5d2d73507