### PR TITLE
Add OCI provenance labels to final image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -117,6 +117,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Prepare build metadata
+        id: meta
+        run: |
+          echo "build-date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+          echo "source-url=${{ github.server_url }}/${{ github.repository }}" >> $GITHUB_OUTPUT
+          echo "documentation-url=${{ github.server_url }}/${{ github.repository }}#readme" >> $GITHUB_OUTPUT
+          echo "ref-name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.check-existing.outputs.target-tag }}" >> $GITHUB_OUTPUT
+
       - name: Build container image
         id: build
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
@@ -130,6 +138,12 @@ jobs:
             ZFS_VERSION=${{ needs.query-versions.outputs.zfs-tag }}
             FEDORA_VERSION=${{ needs.query-versions.outputs.fedora-version }}
             KERNEL_MAJOR_MINOR=${{ needs.query-versions.outputs.kernel-major-minor }}
+            KERNEL_VERSION=${{ needs.query-versions.outputs.kernel-version }}
+            BUILD_DATE=${{ steps.meta.outputs.build-date }}
+            VCS_REF=${{ github.sha }}
+            SOURCE_URL=${{ steps.meta.outputs.source-url }}
+            DOCUMENTATION_URL=${{ steps.meta.outputs.documentation-url }}
+            REF_NAME=${{ steps.meta.outputs.ref-name }}
 
       - name: Log in to Container Registry
         uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7

--- a/Justfile
+++ b/Justfile
@@ -88,6 +88,11 @@ build:
     KERNEL_VERSION=$(just kernel-version)
     KERNEL_MAJOR_MINOR=$(just kernel-major-minor)
     FEDORA_VERSION=$(just fedora-version)
+    BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    VCS_REF=$(git rev-parse HEAD)
+    SOURCE_URL="https://github.com/samhclark/fedora-zfs-kmods"
+    DOCUMENTATION_URL="https://github.com/samhclark/fedora-zfs-kmods#readme"
+    REF_NAME="fedora-zfs-kmods:zfs-${ZFS_VERSION#zfs-}_kernel-${KERNEL_VERSION}"
     
     echo "Building with:"
     echo "  ZFS_VERSION=$ZFS_VERSION"
@@ -98,7 +103,13 @@ build:
     podman build --rm \
         --build-arg ZFS_VERSION="$ZFS_VERSION" \
         --build-arg KERNEL_MAJOR_MINOR="$KERNEL_MAJOR_MINOR" \
+        --build-arg KERNEL_VERSION="$KERNEL_VERSION" \
         --build-arg FEDORA_VERSION="$FEDORA_VERSION" \
+        --build-arg BUILD_DATE="$BUILD_DATE" \
+        --build-arg VCS_REF="$VCS_REF" \
+        --build-arg SOURCE_URL="$SOURCE_URL" \
+        --build-arg DOCUMENTATION_URL="$DOCUMENTATION_URL" \
+        --build-arg REF_NAME="$REF_NAME" \
         -t "fedora-zfs-kmods:zfs-${ZFS_VERSION#zfs-}_kernel-${KERNEL_VERSION}" \
         .
 
@@ -108,8 +119,13 @@ test-build:
     just check-compatibility
     
     ZFS_VERSION=$(just zfs-version)
+    KERNEL_VERSION=$(just kernel-version)
     KERNEL_MAJOR_MINOR=$(just kernel-major-minor)
     FEDORA_VERSION=$(just fedora-version)
+    BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    VCS_REF=$(git rev-parse HEAD)
+    SOURCE_URL="https://github.com/samhclark/fedora-zfs-kmods"
+    DOCUMENTATION_URL="https://github.com/samhclark/fedora-zfs-kmods#readme"
     
     echo "Test building with:"
     echo "  ZFS_VERSION=$ZFS_VERSION"
@@ -120,7 +136,13 @@ test-build:
     podman build --rm \
         --build-arg ZFS_VERSION="$ZFS_VERSION" \
         --build-arg KERNEL_MAJOR_MINOR="$KERNEL_MAJOR_MINOR" \
+        --build-arg KERNEL_VERSION="$KERNEL_VERSION" \
         --build-arg FEDORA_VERSION="$FEDORA_VERSION" \
+        --build-arg BUILD_DATE="$BUILD_DATE" \
+        --build-arg VCS_REF="$VCS_REF" \
+        --build-arg SOURCE_URL="$SOURCE_URL" \
+        --build-arg DOCUMENTATION_URL="$DOCUMENTATION_URL" \
+        --build-arg REF_NAME="fedora-zfs-kmods:test" \
         -t "fedora-zfs-kmods:test" \
         . && podman rmi "fedora-zfs-kmods:test"
 


### PR DESCRIPTION
## Summary
- add OCI-compliant provenance labels to the final scratch image stage
- plumb build metadata through local Justfile helpers and the CI workflow

## Testing
- just check-compatibility *(fails locally: missing `gh` CLI and registry access in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f4481361088329b02c0ecb2d084a7c