### PR TITLE
Add ZFS 2.3.5 tarball hash and document hash updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ When a new ZFS version is released:
 2. **Update the compatibility matrix** in both:
    - `Justfile` (line ~40-45)
    - `.github/workflows/build.yaml` (line ~67-73)
-3. **Test locally** with `just build`
-4. **Run the workflow** to build and publish
+3. **Record the tarball hash** in `scripts/zfs-source-hashes.sh` using `just zfs-tarball-hash <version>`
+4. **Test locally** with `just build`
+5. **Run the workflow** to build and publish
 
 ### Upgrading to New Major/Minor Versions
 

--- a/scripts/zfs-source-hashes.sh
+++ b/scripts/zfs-source-hashes.sh
@@ -9,6 +9,7 @@ declare -A ZFS_TARBALL_SHA256S=(
   ["zfs-2.3.2"]="877a6b37755245955fadd68cee2f2729f7acc10e2aad5dd77a6426a8d46aca83"
   ["zfs-2.3.3"]="ba8db7766e6724dc1c1b9287174bc9022dab521919d3353dc488aad9e55de541"
   ["zfs-2.3.4"]="940af1303a01df3228b3e136a2ae99bb4d7a894f71f804cf7d3ae198f959dd46"
+  ["zfs-2.3.5"]="f7513a31368924493b1715439337f3f7720a5d8d873300c6cd1741fac8616b85"
 )
 
 lookup_zfs_tarball_hash() {


### PR DESCRIPTION
## Summary
- add the ZFS 2.3.5 tarball sha256 to scripts/zfs-source-hashes.sh
- document adding the tarball hash when introducing new ZFS versions

## Testing
- `just test-build` *(fails: missing gh/podman/container runtime in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f1eed64f083299773b321451365eb)