### PR TITLE
ci: Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependabot configuration for automatic dependency updates
+# See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Monitor GitHub Actions workflows for action version updates
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "13:50"  # 7:50 AM CST / 8:50 AM CDT
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 10
+
+  # Monitor Containerfile for base image updates
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "13:50"  # 7:50 AM CST / 8:50 AM CDT
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Configure Dependabot to monitor GitHub Actions and Docker dependencies with weekly checks on Saturday mornings (7:50 AM Central Time).

- Monitor GitHub Actions workflow dependencies for version updates
- Monitor Containerfile base images for security updates
- Run weekly on Saturdays at 13:50 UTC (7:50 AM CST / 8:50 AM CDT)
- Label PRs appropriately for easy identification
- Limit to 10 open PRs per ecosystem to avoid overwhelming the repo