### PR TITLE
Add ZFS 2.4.1 support with Linux 6.19 kernel compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ghcr.io/samhclark/fedora-zfs-kmods:zfs-{zfs-version}_kernel-{kernel-version}
 
 Example:
 ```
-ghcr.io/samhclark/fedora-zfs-kmods:zfs-2.4.0_kernel-6.18.3-200.fc42.x86_64
+ghcr.io/samhclark/fedora-zfs-kmods:zfs-2.4.1_kernel-6.18.3-200.fc42.x86_64
 ```
 
 Where:
@@ -104,6 +104,7 @@ declare -A compatibility_matrix=(
     ["zfs-2.3.4"]="6.16"
     ["zfs-2.3.5"]="6.17"
     ["zfs-2.4.0"]="6.18"
+    ["zfs-2.4.1"]="6.19"
 )
 ```
 
@@ -227,7 +228,7 @@ ARG KERNEL_MAJOR_MINOR
 
 # Stage 2: Pull pre-built ZFS RPMs  
 # IMPORTANT: Must match exact ZFS and kernel versions
-ARG ZFS_VERSION=2.4.0
+ARG ZFS_VERSION=2.4.1
 ARG KERNEL_VERSION=6.18.3-200.fc42.x86_64
 FROM ghcr.io/samhclark/fedora-zfs-kmods:zfs-${ZFS_VERSION}_kernel-${KERNEL_VERSION} as zfs-rpms
 

--- a/scripts/check-compatibility.sh
+++ b/scripts/check-compatibility.sh
@@ -28,6 +28,7 @@ declare -A COMPATIBILITY_MATRIX=(
   ["zfs-2.3.4"]="6.16"
   ["zfs-2.3.5"]="6.17"
   ["zfs-2.4.0"]="6.18"
+  ["zfs-2.4.1"]="6.19"
 )
 
 MAX_KERNEL=${COMPATIBILITY_MATRIX[$ZFS_VERSION]:-}

--- a/scripts/zfs-source-hashes.sh
+++ b/scripts/zfs-source-hashes.sh
@@ -11,6 +11,7 @@ declare -A ZFS_TARBALL_SHA256S=(
   ["zfs-2.3.4"]="940af1303a01df3228b3e136a2ae99bb4d7a894f71f804cf7d3ae198f959dd46"
   ["zfs-2.3.5"]="f7513a31368924493b1715439337f3f7720a5d8d873300c6cd1741fac8616b85"
   ["zfs-2.4.0"]="84a37d5096b189375d2dbb74759d4dee8a5fcf14c9c3039d5397ce5019af133c"
+  ["zfs-2.4.1"]="b6129b23e6bc6deb75d9fa4f1c24c5cfc079f849b8840d200c4ad46a2cc1c883"
 )
 
 lookup_zfs_tarball_hash() {


### PR DESCRIPTION
- Add zfs-2.4.1 to compatibility matrix with max kernel 6.19
- Record SHA256 tarball hash for zfs-2.4.1
- Update README compatibility matrix and example container tags

https://claude.ai/code/session_01BdbFtMpr3S5112EESotcf7