### PR TITLE
fix: scheduled cleanup runs were always dry runs

### DIFF
--- a/.github/workflows/cleanup-images.yaml
+++ b/.github/workflows/cleanup-images.yaml
@@ -22,7 +22,7 @@ jobs:
       packages: write
       contents: read
     env:
-      CLEANUP_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'true' }}
+      CLEANUP_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The CLEANUP_DRY_RUN env expression fell back to 'true' when the
workflow was triggered by schedule (not workflow_dispatch), making
every scheduled run a dry run that never deleted anything.

Change the fallback from 'true' to 'false' so:
- Scheduled runs: CLEANUP_DRY_RUN=false  → real deletion
- Manual dispatch dry_run=true:  CLEANUP_DRY_RUN=true  → dry run
- Manual dispatch dry_run=false: CLEANUP_DRY_RUN=false → real deletion

https://claude.ai/code/session_01Y4eS8PDYit9aQPd1pPR3WZ