### PR TITLE
Add ZFS 2.4.2 support with kernel 7.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ghcr.io/samhclark/fedora-zfs-kmods:zfs-{zfs-version}_kernel-{kernel-version}
 
 Example:
 ```
-ghcr.io/samhclark/fedora-zfs-kmods:zfs-2.4.1_kernel-6.18.7-200.fc43.x86_64
+ghcr.io/samhclark/fedora-zfs-kmods:zfs-2.4.2_kernel-6.18.7-200.fc43.x86_64
 ```
 
 Where:
@@ -105,6 +105,7 @@ declare -A compatibility_matrix=(
     ["zfs-2.3.5"]="6.17"
     ["zfs-2.4.0"]="6.18"
     ["zfs-2.4.1"]="6.19"
+    ["zfs-2.4.2"]="7.0"
 )
 ```
 
@@ -228,7 +229,7 @@ ARG KERNEL_MAJOR_MINOR
 
 # Stage 2: Pull pre-built ZFS RPMs  
 # IMPORTANT: Must match exact ZFS and kernel versions
-ARG ZFS_VERSION=2.4.1
+ARG ZFS_VERSION=2.4.2
 ARG KERNEL_VERSION=6.18.3-200.fc42.x86_64
 FROM ghcr.io/samhclark/fedora-zfs-kmods:zfs-${ZFS_VERSION}_kernel-${KERNEL_VERSION} as zfs-rpms
 

--- a/scripts/check-compatibility.sh
+++ b/scripts/check-compatibility.sh
@@ -29,6 +29,7 @@ declare -A COMPATIBILITY_MATRIX=(
   ["zfs-2.3.5"]="6.17"
   ["zfs-2.4.0"]="6.18"
   ["zfs-2.4.1"]="6.19"
+  ["zfs-2.4.2"]="7.0"
 )
 
 MAX_KERNEL=${COMPATIBILITY_MATRIX[$ZFS_VERSION]:-}

--- a/scripts/zfs-source-hashes.sh
+++ b/scripts/zfs-source-hashes.sh
@@ -12,6 +12,7 @@ declare -A ZFS_TARBALL_SHA256S=(
   ["zfs-2.3.5"]="f7513a31368924493b1715439337f3f7720a5d8d873300c6cd1741fac8616b85"
   ["zfs-2.4.0"]="84a37d5096b189375d2dbb74759d4dee8a5fcf14c9c3039d5397ce5019af133c"
   ["zfs-2.4.1"]="b6129b23e6bc6deb75d9fa4f1c24c5cfc079f849b8840d200c4ad46a2cc1c883"
+  ["zfs-2.4.2"]="7e260d0e6af295bea4c5e241cac0a1aef07b58d8dd8035f7898ade3b1bbec78f"
 )
 
 lookup_zfs_tarball_hash() {


### PR DESCRIPTION
- Add zfs-2.4.2 → 7.0 to compatibility matrix in check-compatibility.sh
- Add SHA256 hash for zfs-2.4.2 tarball to zfs-source-hashes.sh
- Update README compatibility matrix and example version references

https://claude.ai/code/session_01LmBAHzPJGbgRtAdoATcP8p