### PR TITLE
Fix zfs-2.4.2 tarball hash and document correct hash method

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,16 @@ This replaces ~40 lines of ZFS build-from-source with 3 lines of RPM installatio
 - Compatibility matrix must be updated for each new ZFS release
 - Build fails safe when encountering unknown versions
 
+### Getting the Correct Tarball Hash
+
+When adding a new ZFS version to `scripts/zfs-source-hashes.sh`, **always use `just zfs-tarball-hash <tag>`** to compute the hash. This command downloads the tarball from the GitHub archive URL (`https://github.com/openzfs/zfs/archive/refs/tags/<tag>.tar.gz`) which is what the Containerfile fetches at build time.
+
+```bash
+just zfs-tarball-hash zfs-2.4.2
+```
+
+Do **not** use hashes from the GitHub release page assets (e.g., `zfs-2.4.2.tar.gz` listed under release assets) — those are release tarballs with a different hash than the archive tarball.
+
 ## Container Attestations
 
 GitHub Actions automatically generates and publishes build attestations alongside container images. These attestations are critical for security verification and cannot be deleted independently from their parent containers.

--- a/scripts/zfs-source-hashes.sh
+++ b/scripts/zfs-source-hashes.sh
@@ -12,7 +12,7 @@ declare -A ZFS_TARBALL_SHA256S=(
   ["zfs-2.3.5"]="f7513a31368924493b1715439337f3f7720a5d8d873300c6cd1741fac8616b85"
   ["zfs-2.4.0"]="84a37d5096b189375d2dbb74759d4dee8a5fcf14c9c3039d5397ce5019af133c"
   ["zfs-2.4.1"]="b6129b23e6bc6deb75d9fa4f1c24c5cfc079f849b8840d200c4ad46a2cc1c883"
-  ["zfs-2.4.2"]="7e260d0e6af295bea4c5e241cac0a1aef07b58d8dd8035f7898ade3b1bbec78f"
+  ["zfs-2.4.2"]="d03c3edd320993bb04d6ec2c8c7300b87487c7b10ff5742f13a437a5164ba718"
 )
 
 lookup_zfs_tarball_hash() {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Corrects the SHA256 hash for `zfs-2.4.2` in `scripts/zfs-source-hashes.sh` — the previous hash was taken from the GitHub release asset, but the Containerfile fetches from the GitHub archive URL (`/archive/refs/tags/`), which is a different tarball with a different hash
- Adds a "Getting the Correct Tarball Hash" section to `AGENTS.md` documenting that `just zfs-tarball-hash <tag>` must be used, not hashes from the release assets page

## Test plan

- [ ] Verify `scripts/zfs-source-hashes.sh zfs-2.4.2` returns the corrected hash
- [ ] Trigger a build to confirm the tarball downloads and verifies successfully

https://claude.ai/code/session_01LmBAHzPJGbgRtAdoATcP8p
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmBAHzPJGbgRtAdoATcP8p)_